### PR TITLE
Add support for dangling vertices in PageRank

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <graphalytics.version>1.1.0</graphalytics.version>
+        <graphalytics.version>1.2.0-SNAPSHOT</graphalytics.version>
         <flink.version>1.9.0</flink.version>
         <hadoop.version>2.4.1</hadoop.version>
         <log4j.version>2.5</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -118,8 +118,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/science/atlarge/graphalytics/flink/GellyPlatform.java
+++ b/src/main/java/science/atlarge/graphalytics/flink/GellyPlatform.java
@@ -188,8 +188,7 @@ public class GellyPlatform extends AbstractPlatform {
 					new LocalClusteringCoefficient(isDirected), hasEdgeValues);
 				break;
 			case "PR": job = new GellyJob<>(remoteEnv, vertexPath, edgesPath, outputPath,
-					new ScatterGatherPageRank(
-							parameters, input.getNumberOfVertices()), hasEdgeValues);
+					new ScatterGatherPageRank(parameters), hasEdgeValues);
 				break;
 			case "SSSP": job = new GellyJob<>(remoteEnv, vertexPath, edgesPath, outputPath,
 					new ScatterGatherSSSP(parameters), hasEdgeValues);

--- a/src/test/java/gelly/graphalytics/GatherScatterPageRankJobTest.java
+++ b/src/test/java/gelly/graphalytics/GatherScatterPageRankJobTest.java
@@ -1,21 +1,23 @@
 package gelly.graphalytics;
 
-import org.junit.Ignore;
-import science.atlarge.graphalytics.domain.algorithms.PageRankParameters;
-import science.atlarge.graphalytics.flink.algorithms.pr.ScatterGatherPageRank;
-import science.atlarge.graphalytics.validation.GraphStructure;
-import science.atlarge.graphalytics.validation.algorithms.pr.PageRankOutput;
-import science.atlarge.graphalytics.validation.algorithms.pr.PageRankValidationTest;
 import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.graph.Edge;
 import org.apache.flink.graph.Graph;
 import org.apache.flink.types.NullValue;
+import science.atlarge.graphalytics.domain.algorithms.PageRankParameters;
+import science.atlarge.graphalytics.flink.algorithms.pr.ScatterGatherPageRank;
+import science.atlarge.graphalytics.validation.GraphStructure;
+import science.atlarge.graphalytics.validation.algorithms.pr.PageRankOutput;
+import science.atlarge.graphalytics.validation.algorithms.pr.PageRankValidationTest;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-@Ignore
 public class GatherScatterPageRankJobTest extends PageRankValidationTest {
 
     @Override
@@ -24,8 +26,7 @@ public class GatherScatterPageRankJobTest extends PageRankValidationTest {
 
         Graph<Long, NullValue, NullValue> input = getInputGraph(graphStructure);
         // run the PageRank job
-        DataSet<Tuple2<Long, Double>> result = input.run(
-                new ScatterGatherPageRank(params, graphStructure.getVertices().size()));
+        DataSet<Tuple2<Long, Double>> result = input.run(new ScatterGatherPageRank(params));
         return convertResult(result);
     }
 
@@ -35,8 +36,7 @@ public class GatherScatterPageRankJobTest extends PageRankValidationTest {
 
         Graph<Long, NullValue, NullValue> input = getInputGraph(graphStructure);
         // run the PageRank job
-        DataSet<Tuple2<Long, Double>> result = input.run(
-                new ScatterGatherPageRank(params, graphStructure.getVertices().size()));
+        DataSet<Tuple2<Long, Double>> result = input.run(new ScatterGatherPageRank(params));
         return convertResult(result);
     }
 


### PR DESCRIPTION
Fixes #4.

Code can be built with the [latest Graphalytics version](https://github.com/ldbc/ldbc_graphalytics/), `1.2.0-SNAPSHOT`.