### PR TITLE
Bump Graphalytics version to 1.2.0 stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <graphalytics.version>1.2.0-SNAPSHOT</graphalytics.version>
+        <graphalytics.version>1.2.0</graphalytics.version>
         <flink.version>1.9.0</flink.version>
         <hadoop.version>2.4.1</hadoop.version>
         <log4j.version>2.5</log4j.version>


### PR DESCRIPTION
Graphalytics version 1.2.0 stable has just been released in the Graphalytics Maven repository: https://atlarge.ewi.tudelft.nl/graphalytics/mvn/science/atlarge/graphalytics/graphalytics-core/1.2.0/